### PR TITLE
Fixed CLI bug

### DIFF
--- a/src/main/java/edu/pdx/cs510/agile/team3/FTP/CLIClient.java
+++ b/src/main/java/edu/pdx/cs510/agile/team3/FTP/CLIClient.java
@@ -183,7 +183,12 @@ public class CLIClient {
         int port = 21;
         if (line.hasOption("port")) {
             String portstring = line.getOptionValue("port");
-            port = Integer.parseInt(portstring);
+            try {
+                port = Integer.parseInt(portstring);
+            }
+            catch (java.lang.NumberFormatException e) {
+                port = 21;
+            }
         }
 
         FTPServerInfo serverInfo = new FTPServerInfo(


### PR DESCRIPTION
Fixed a small bug in the CLI. If the user gave a non-integer port option (or any CLI option starting with p!) the program would crash. Now it just defaults to port 21.